### PR TITLE
Adding more tests to AtomGroup testing

### DIFF
--- a/lahuta/contacts/__init__.py
+++ b/lahuta/contacts/__init__.py
@@ -45,7 +45,7 @@ from .hbonds import HBondContacts, PolarHBondContacts, WeakHBondContacts, WeakPo
 from .hydrophobic import HydrophobicContacts
 from .ionic import IonicContacts
 from .metal import MetalicContacts
-from .plane_plane import plane_plane_neighbors
+from .plane_plane import PlanePlaneContacts, plane_plane_neighbors
 from .sulphur_pi import SulphurPi
 from .vdw import VanDerWaalsContacts
 
@@ -82,4 +82,5 @@ __all__ = [
     "DonorPi",
     "SulphurPi",
     "AtomPlaneContacts",
+    "PlanePlaneContacts",
 ]

--- a/lahuta/lahuta_types/mdanalysis.py
+++ b/lahuta/lahuta_types/mdanalysis.py
@@ -104,6 +104,10 @@ class AtomGroupType(Protocol):
         ...
 
     @property
+    def resname(self) -> NDArray[np.str_]:
+        ...
+
+    @property
     def resids(self) -> NDArray[np.int32]:
         ...
 

--- a/lahuta/tests/test_ag_processing.py
+++ b/lahuta/tests/test_ag_processing.py
@@ -90,6 +90,7 @@ class TestMDAnalysis:
         selection, res_dif = request.param
         with warnings.catch_warnings(record=True) as _:
             self.universe = UniverseWrapper(mda_universe, selection, universe_ref)
+            self.mda = self.universe.u_ref.to("mda")
 
         self.contact_types = [
             ContactType("covalent", C.covalent_neighbors, self.universe),
@@ -121,3 +122,20 @@ class TestMDAnalysis:
             assert (
                 contact_type.pairs() <= contact_type.pairs_ref()
             ), f"{contact_type.name} neighbors pairs are not less than or equal to the reference neighbors pairs"
+
+    def test_correct_residue_content(self) -> None:
+        atoms = self.mda.universe.atoms
+        assert atoms is not None
+        for contact_type in self.contact_types:
+            if contact_type.name == "covalent":
+                continue
+            assert contact_type.neighbors_diff is not None
+            for pair in contact_type.neighbors_diff.pairs:
+                x1, x2 = atoms[pair[0]], atoms[pair[1]]
+                if x1.resname in self.universe.unique_resnames or x2.resname in self.universe.unique_resnames:
+                    continue
+                # fail test if we get here
+                assert (
+                    False
+                ), f"Pair {pair} with resnames {x1.resname} and {x2.resname} got wrongly picked up by {contact_type.name} neighbors"
+            assert True


### PR DESCRIPTION
This PR adds one more test that is a lot more strict in ensuring we do not pick up contacts with filtered-out residues. 