### PR TITLE
Publish conda package on new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
-name: Publish Conda Package on Release
+name: Publish Conda Package
 
 on:
-  push:
-    branches: ["dev_publish"]
-
+  release:
+    types: [published]
 
 jobs:
   trigger:


### PR DESCRIPTION
This GitHub Action should publish the package to Anaconda Cloud whenever there's a new release. 