### PR TITLE
fix: send log messages to stderr instead of stdout

### DIFF
--- a/cli/runner/reporting.hpp
+++ b/cli/runner/reporting.hpp
@@ -220,7 +220,7 @@ inline std::shared_ptr<ProgRunObs> attach_progress_observer(StageManager &manage
     }
   }
   if (!base_sink) {
-    base_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    base_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
   }
   std::shared_ptr<spdlog::sinks::sink> progress_sink;
   if (std::dynamic_pointer_cast<spdlog::sinks::stderr_color_sink_mt>(base_sink)) {
@@ -228,7 +228,7 @@ inline std::shared_ptr<ProgRunObs> attach_progress_observer(StageManager &manage
   } else if (std::dynamic_pointer_cast<spdlog::sinks::stdout_color_sink_mt>(base_sink)) {
     progress_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
   } else {
-    progress_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    progress_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
   }
   bool inline_color = false;
 #ifdef _WIN32

--- a/core/src/logging/logging.cpp
+++ b/core/src/logging/logging.cpp
@@ -40,7 +40,7 @@ void Logger::set_log_level(LogLevel level) {
 Logger::LogLevel Logger::get_log_level() { return static_cast<LogLevel>(logger->level()); }
 
 void Logger::configure_for_spinner(indicators::MinimalProgressSpinner *spinner, std::mutex &spinner_mutex) {
-  auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+  auto console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
   std::shared_ptr<spdlog::sinks::sink> sink;
   if (spinner) {
     sink = std::make_shared<indicators::SpinnerAwareSink>(console_sink, spinner, spinner_mutex);
@@ -68,7 +68,7 @@ Logger::Logger() {
   if (existing) {
     logger = existing;
   } else {
-    logger = spdlog::stdout_color_mt("console");
+    logger = spdlog::stderr_color_mt("console");
   }
   // Make this the default logger within this registry to keep free-function calls consistent in this TU
   if (logger) {


### PR DESCRIPTION
In CLI mode, sends logging messages to stderr rather than stdout, as per usual Unix convention. This prevents log messages from mixing with data output when using -o flag (e.g.,`lahuta contacts --file structure.pdb -o - >contacts.jsonl`).